### PR TITLE
Fixed accidentally swapped label and name of the password

### DIFF
--- a/config/user_preferences_extra_conf.yml
+++ b/config/user_preferences_extra_conf.yml
@@ -10,7 +10,7 @@ preferences:
         label: Username
         type: text
         required: False
-      - name: Password
-        label: password
+      - name: password
+        label: Password
         type: password
         required: False


### PR DESCRIPTION
Tiny fix that is very important for reading the password as the name and label were swapped